### PR TITLE
Refactor update scripts with shared helpers

### DIFF
--- a/core/version_check.py
+++ b/core/version_check.py
@@ -1,0 +1,49 @@
+import os
+import ssl
+import requests
+from include_tgram import sendtotelegram
+
+
+def fetch_json(url, verify_ssl=True):
+    """Retrieve JSON data from URL with optional SSL verification."""
+    if not verify_ssl and not os.environ.get('PYTHONHTTPSVERIFY', '') and getattr(ssl, '_create_unverified_context', None):
+        ssl._create_default_https_context = ssl._create_unverified_context
+    response = requests.get(url, verify=verify_ssl)
+    response.raise_for_status()
+    return response.json()
+
+
+def read_repo_version(filename):
+    """Read first line of version file, return None if file missing."""
+    if not os.path.exists(filename):
+        return None
+    with open(filename, 'r') as fh:
+        content = fh.read()
+        return content.split('\n', 1)[0]
+
+
+def write_repo_version(filename, version):
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
+    with open(filename, 'w') as fh:
+        fh.write(version)
+
+
+def notify_telegram(message):
+    """Proxy include_tgram.sendtotelegram."""
+    return sendtotelegram(message)
+
+
+def run_check(name, fetch_fn, version_file, message_fmt):
+    data = fetch_fn()
+    if isinstance(data, dict):
+        version = data.get('version')
+    else:
+        version = data
+        data = {'version': version}
+    repo_version = read_repo_version(version_file)
+    if version != repo_version:
+        print(f"New version of {name} is available: {version}, updating version file.")
+        write_repo_version(version_file, version)
+        notify_telegram(message_fmt.format(**data))
+    else:
+        print(f"Latest {name} is the same as the repository, skipping.")

--- a/sw_7zip.py
+++ b/sw_7zip.py
@@ -1,42 +1,23 @@
-import requests
-import ssl
-import json
 import os
-import os.path
-from jsondiff import diff
-from include_tgram import *
+from core.version_check import fetch_json, run_check
 
-def sourceJson(path):
-    if (not os.environ.get('PYTHONHTTPSVERIFY', '') and getattr(ssl, '_create_unverified_context', None)): # Credits: https://moreless.medium.com/how-to-fix-python-ssl-certificate-verify-failed-97772d9dd14c
-        ssl._create_default_https_context = ssl._create_unverified_context
-    response = json.loads(requests.get(path).text)
-    return response
 
-def cleanVersion(filename):
-    first_slash_index = filename.index("/", 1) # Trova l'indice del primo e del secondo "/" che delimitano la versione
+def clean_version(filename):
+    first_slash_index = filename.index("/", 1)
     second_slash_index = filename.index("/", first_slash_index + 1)
-    version = filename[first_slash_index + 1:second_slash_index] # Estrae la versione dalla stringa
-    return version
+    return filename[first_slash_index + 1:second_slash_index]
 
-def checkrepo(updates_file):
-    with open(updates_file, "r") as f:
-        content = f.read()
-        first_line = content.split('\n', 1)[0]
-    return first_line
 
-def checkversion(sevenzipVersion):
-    if (sevenzipVersion != checkrepo(os.path.join("updates","LATEST_7ZIP"))):
-        print("New version of 7-Zip is available: %s, i'm updating version file." % sevenzipVersion)
-        writenewversion(os.path.join("updates","LATEST_7ZIP"),sevenzipVersion)
-        sendtotelegram("🤐 7-Zip: new version %s available! \nDownload from %s" % (sevenzipVersion,sevenzipJson["release"]["url"]))
-    else:
-        print("Latest 7-Zip is the same of the repository, skip.")
+def fetch_sevenzip():
+    data = fetch_json("https://sourceforge.net/projects/sevenzip/best_release.json")
+    version = clean_version(data["release"]["filename"])
+    return {"version": version, "url": data["release"]["url"]}
 
-def writenewversion(updates_file,newversion):
-    with open(updates_file, "w") as readversion:
-        readversion.write(newversion)
-    return
 
-sevenzipJson = sourceJson("https://sourceforge.net/projects/sevenzip/best_release.json") # Credits: https://github.com/UNT-CAS/SourceForge-API/blob/master/sourceforge.ps1
-sevenzipCleanVersion = cleanVersion(sevenzipJson["release"]["filename"])
-checkversion(sevenzipCleanVersion)
+if __name__ == "__main__":
+    run_check(
+        "7-Zip",
+        fetch_sevenzip,
+        os.path.join("updates", "LATEST_7ZIP"),
+        "\U0001F910 7-Zip: new version {version} available! \nDownload from {url}",
+    )

--- a/sw_filezilla.py
+++ b/sw_filezilla.py
@@ -1,7 +1,11 @@
-import requests
-import re
 import os
-from include_tgram import *
+import re
+import requests
+from core.version_check import run_check
+
+
+URL = "https://filezilla-project.org/download.php?show_all=1"
+
 
 def get_latest_version_from_html(url):
     session = requests.Session()
@@ -12,46 +16,23 @@ def get_latest_version_from_html(url):
         response = session.get(url, headers=headers, timeout=10)
         response.raise_for_status()
         html_content = response.text
-
         match = re.search(r'FileZilla_(\d+\.\d+\.\d+)_', html_content)
         if match:
-            latest_version = match.group(1)
-            return latest_version
-        else:
-            print("No matching version found in the HTML.")
-            return None
+            return match.group(1)
     except requests.RequestException as e:
         print(f"Error fetching the page: {e}")
-        return None
+    return None
 
-def checkrepo(updates_file):
-    if not os.path.exists(updates_file):
-        return None
-    with open(updates_file, "r") as f:
-        content = f.read()
-        first_line = content.split('\n', 1)[0]
-    return first_line
 
-def checkversion(fzversion):
-    if not fzversion:
-        print("No valid version found. Exiting.")
-        return
-    updates_file = os.path.join("updates", "LATEST_FILEZILLA")
-    repo_version = checkrepo(updates_file)
+def fetch_filezilla():
+    version = get_latest_version_from_html(URL)
+    return {"version": version}
 
-    if fzversion != repo_version:
-        print(f"New version of FileZilla is available: {fzversion}, updating version file.")
-        writenewversion(updates_file, fzversion)
-        sendtotelegram(f"🔌 FileZilla: new version available! {fzversion}\nDownload from https://filezilla-project.org/download.php?show_all=1")
-    else:
-        print("Latest FileZilla is the same as the repository, skipping.")
 
-def writenewversion(updates_file, newversion):
-    with open(updates_file, "w") as readversion:
-        readversion.write(newversion)
-    return
-
-url = "https://filezilla-project.org/download.php?show_all=1"
-fzversion = get_latest_version_from_html(url)
-print(f"Latest version found: {fzversion}")
-checkversion(fzversion)
+if __name__ == "__main__":
+    run_check(
+        "FileZilla",
+        fetch_filezilla,
+        os.path.join("updates", "LATEST_FILEZILLA"),
+        "\U0001F50C FileZilla: new version available! {version}\nDownload from " + URL,
+    )

--- a/sw_firma4ng.py
+++ b/sw_firma4ng.py
@@ -1,37 +1,25 @@
-import urllib.request
 import hashlib
-import ssl
 import os
-import os.path
-from include_tgram import *
+import ssl
+import urllib.request
+from core.version_check import run_check
 
-def sourceWeb(path):
-    if (not os.environ.get('PYTHONHTTPSVERIFY', '') and getattr(ssl, '_create_unverified_context', None)): # Credits: https://moreless.medium.com/how-to-fix-python-ssl-certificate-verify-failed-97772d9dd14c
+URL = "https://card.infocamere.it/infocard/FileDocManager/download?file=/firma4ng/Firma4ng_win.zip"
+
+
+def fetch_firma4ng():
+    if not os.environ.get('PYTHONHTTPSVERIFY', '') and getattr(ssl, '_create_unverified_context', None):
         ssl._create_default_https_context = ssl._create_unverified_context
-    response = urllib.request.urlopen(path)
-    data = response.read()
+    data = urllib.request.urlopen(URL).read()
     md5 = hashlib.md5()
     md5.update(data)
-    return md5.hexdigest()
+    return {"version": md5.hexdigest()}
 
-def checkrepo(updates_file):
-    with open(updates_file, "r") as f:
-        content = f.read()
-        first_line = content.split('\n', 1)[0]
-    return first_line
 
-def checkversion(gsdmd5):
-    if (gsdmd5 != checkrepo(os.path.join("updates","LATEST_FIRMA4NG"))):
-        print("New version of Firma4NG is available: %s, i'm updating version file." % gsdmd5)
-        writenewversion(os.path.join("updates","LATEST_FIRMA4NG"),gsdmd5)
-        sendtotelegram("✏️ Firma4NG: new version available! Updated MD5: %s \nDownload from https://card.infocamere.it/infocard/FileDocManager/download?file=/firma4ng/Firma4ng_win.zip" % gsdmd5)
-    else:
-        print("Latest Firma4NG is the same of the repository, skip.")
-
-def writenewversion(updates_file,newversion):
-    with open(updates_file, "w") as readversion:
-        readversion.write(newversion)
-    return
-
-gsdmd5 = sourceWeb("https://card.infocamere.it/infocard/FileDocManager/download?file=/firma4ng/Firma4ng_win.zip")
-checkversion(gsdmd5)
+if __name__ == "__main__":
+    run_check(
+        "Firma4NG",
+        fetch_firma4ng,
+        os.path.join("updates", "LATEST_FIRMA4NG"),
+        "\u270F\uFE0F Firma4NG: new version available! Updated MD5:{version} \nDownload from " + URL,
+    )

--- a/sw_imgmgck.py
+++ b/sw_imgmgck.py
@@ -1,35 +1,18 @@
-import requests
-import ssl
-import json
 import os
-import os.path
-from jsondiff import diff
-from include_tgram import *
+from core.version_check import fetch_json, run_check
 
-def sourceJson(path):
-    if (not os.environ.get('PYTHONHTTPSVERIFY', '') and getattr(ssl, '_create_unverified_context', None)): # Credits: https://moreless.medium.com/how-to-fix-python-ssl-certificate-verify-failed-97772d9dd14c
-        ssl._create_default_https_context = ssl._create_unverified_context
-    response = json.loads(requests.get(path).text)
-    return response
+URL = "https://api.github.com/repos/ImageMagick/ImageMagick/releases/latest"
 
-def checkrepo(updates_file):
-    with open(updates_file, "r") as f:
-        content = f.read()
-        first_line = content.split('\n', 1)[0]
-    return first_line
 
-def checkversion(imgmgckversion):
-    if (imgmgckversion != checkrepo(os.path.join("updates","LATEST_IMGMGCK"))):
-        print("New version of ImageMagick is available: %s, i'm updating version file." % imgmgckversion)
-        writenewversion(os.path.join("updates","LATEST_IMGMGCK"),imgmgckversion)
-        sendtotelegram("🖼️ ImageMagick: new version available! %s \nDownload from %s (or, as alternative, https://imagemagick.org/script/download.php)" % (imgmgckversion,imgmgckJson["html_url"]))
-    else:
-        print("Latest ImageMagick is the same of the repository, skip.")
+def fetch_imagemagick():
+    data = fetch_json(URL)
+    return {"version": data["tag_name"], "url": data["html_url"]}
 
-def writenewversion(updates_file,newversion):
-    with open(updates_file, "w") as readversion:
-        readversion.write(newversion)
-    return
 
-imgmgckJson = sourceJson("https://api.github.com/repos/ImageMagick/ImageMagick/releases/latest") # Credits: https://stackoverflow.com/a/60716112/2220346
-checkversion(imgmgckJson["tag_name"])
+if __name__ == "__main__":
+    run_check(
+        "ImageMagick",
+        fetch_imagemagick,
+        os.path.join("updates", "LATEST_IMGMGCK"),
+        "\U0001F5BC\uFE0F ImageMagick: new version available! {version} \nDownload from {url} (or, as alternative, https://imagemagick.org/script/download.php)",
+    )

--- a/sw_naps2.py
+++ b/sw_naps2.py
@@ -1,35 +1,18 @@
-import requests
-import ssl
-import json
 import os
-import os.path
-from jsondiff import diff
-from include_tgram import *
+from core.version_check import fetch_json, run_check
 
-def sourceJson(path):
-    if (not os.environ.get('PYTHONHTTPSVERIFY', '') and getattr(ssl, '_create_unverified_context', None)): # Credits: https://moreless.medium.com/how-to-fix-python-ssl-certificate-verify-failed-97772d9dd14c
-        ssl._create_default_https_context = ssl._create_unverified_context
-    response = json.loads(requests.get(path).text)
-    return response
+URL = "https://api.github.com/repos/cyanfish/naps2/releases/latest"
 
-def checkrepo(updates_file):
-    with open(updates_file, "r") as f:
-        content = f.read()
-        first_line = content.split('\n', 1)[0]
-    return first_line
 
-def checkversion(naps2version):
-    if (naps2version != checkrepo(os.path.join("updates","LATEST_NAPS2"))):
-        print("New version of NAPS2 is available: %s, i'm updating version file." % naps2version)
-        writenewversion(os.path.join("updates","LATEST_NAPS2"),naps2version)
-        sendtotelegram("🖨️ NAPS2: new version available! %s \nDownload from %s" % (naps2version,napsJson["html_url"]))
-    else:
-        print("Latest NAPS2 is the same of the repository, skip.")
+def fetch_naps2():
+    data = fetch_json(URL)
+    return {"version": data["tag_name"], "url": data["html_url"]}
 
-def writenewversion(updates_file,newversion):
-    with open(updates_file, "w") as readversion:
-        readversion.write(newversion)
-    return
 
-napsJson = sourceJson("https://api.github.com/repos/cyanfish/naps2/releases/latest") # Credits: https://stackoverflow.com/a/60716112/2220346
-checkversion(napsJson["tag_name"])
+if __name__ == "__main__":
+    run_check(
+        "NAPS2",
+        fetch_naps2,
+        os.path.join("updates", "LATEST_NAPS2"),
+        "\U0001F5A8\uFE0F NAPS2: new version available! {version} \nDownload from {url}",
+    )

--- a/sw_npp.py
+++ b/sw_npp.py
@@ -1,35 +1,18 @@
-import requests
-import ssl
-import json
 import os
-import os.path
-from jsondiff import diff
-from include_tgram import *
+from core.version_check import fetch_json, run_check
 
-def sourceJson(path):
-    if (not os.environ.get('PYTHONHTTPSVERIFY', '') and getattr(ssl, '_create_unverified_context', None)): # Credits: https://moreless.medium.com/how-to-fix-python-ssl-certificate-verify-failed-97772d9dd14c
-        ssl._create_default_https_context = ssl._create_unverified_context
-    response = json.loads(requests.get(path).text)
-    return response
+URL = "https://api.github.com/repos/notepad-plus-plus/notepad-plus-plus/releases/latest"
 
-def checkrepo(updates_file):
-    with open(updates_file, "r") as f:
-        content = f.read()
-        first_line = content.split('\n', 1)[0]
-    return first_line
 
-def checkversion(nppversion):
-    if (nppversion != checkrepo(os.path.join("updates","LATEST_NPP"))):
-        print("New version of Notepad++ is available: %s, i'm updating version file." % nppversion)
-        writenewversion(os.path.join("updates","LATEST_NPP"),nppversion)
-        sendtotelegram("📝 Notepad➕➕: new version available! %s \nDownload from %s" % (nppversion,nppJson["html_url"]))
-    else:
-        print("Latest Notepad++ is the same of the repository, skip.")
+def fetch_npp():
+    data = fetch_json(URL)
+    return {"version": data["tag_name"], "url": data["html_url"]}
 
-def writenewversion(updates_file,newversion):
-    with open(updates_file, "w") as readversion:
-        readversion.write(newversion)
-    return
 
-nppJson = sourceJson("https://api.github.com/repos/notepad-plus-plus/notepad-plus-plus/releases/latest") # Credits: https://stackoverflow.com/a/60716112/2220346
-checkversion(nppJson["tag_name"])
+if __name__ == "__main__":
+    run_check(
+        "Notepad++",
+        fetch_npp,
+        os.path.join("updates", "LATEST_NPP"),
+        "\U0001F4DD Notepad\u2795\u2795: new version available! {version} \nDownload from {url}",
+    )

--- a/sw_putty.py
+++ b/sw_putty.py
@@ -1,44 +1,27 @@
-import urllib.request
-import ssl
 import os
-import os.path
 import re
-from jsondiff import diff
-from include_tgram import *
+import ssl
+import urllib.request
+from core.version_check import run_check
 
-# New method credits: https://github.com/0install/apps/blob/master/gui/putty.watch.py
+URL = "https://www.chiark.greenend.org.uk/~sgtatham/putty/changes.html"
+DOWNLOAD_URL = "https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html"
 
-def sourceWeb(path):
-    if (not os.environ.get('PYTHONHTTPSVERIFY', '') and getattr(ssl, '_create_unverified_context', None)): # Credits: https://moreless.medium.com/how-to-fix-python-ssl-certificate-verify-failed-97772d9dd14c
+
+def fetch_putty():
+    if not os.environ.get('PYTHONHTTPSVERIFY', '') and getattr(ssl, '_create_unverified_context', None):
         ssl._create_default_https_context = ssl._create_unverified_context
-    data = urllib.request.urlopen(path).read().decode('utf-8')
-    
+    data = urllib.request.urlopen(URL).read().decode('utf-8')
     excluded_versions = ['0.45', '0.46', '0.47', '0.48', '0.49', '0.50', '0.51']
-
-    data = urllib.request.urlopen(path).read().decode('utf-8')
     matches = re.findall(r'>([0-9.]+)<\/a>\n\(released (....-..-..)', data)
-    releases = [{'version': match[0], 'released': match[1]} for match in matches if not match[0] in excluded_versions]
+    releases = [m for m in matches if m[0] not in excluded_versions]
+    return {"version": releases[0][0]}
 
-    return releases[0]["version"]
 
-def checkrepo(updates_file):
-    with open(updates_file, "r") as f:
-        content = f.read()
-        first_line = content.split('\n', 1)[0]
-    return first_line
-
-def checkversion(ptversion):
-    if (ptversion != checkrepo(os.path.join("updates","LATEST_PUTTY"))):
-        print("New version of PuTTY is available: %s, i'm updating version file." % ptversion)
-        writenewversion(os.path.join("updates","LATEST_PUTTY"),ptversion)
-        sendtotelegram("🔌 PuTTY: new version available! %s \nDownload from https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html" % ptversion)
-    else:
-        print("Latest PuTTY is the same of the repository, skip.")
-
-def writenewversion(updates_file,newversion):
-    with open(updates_file, "w") as readversion:
-        readversion.write(newversion)
-    return
-
-ptversion = sourceWeb("https://www.chiark.greenend.org.uk/~sgtatham/putty/changes.html")
-checkversion(ptversion)
+if __name__ == "__main__":
+    run_check(
+        "PuTTY",
+        fetch_putty,
+        os.path.join("updates", "LATEST_PUTTY"),
+        "\U0001F50C PuTTY: new version available! {version} \nDownload from " + DOWNLOAD_URL,
+    )

--- a/sw_xmlnp.py
+++ b/sw_xmlnp.py
@@ -1,35 +1,18 @@
-import requests
-import ssl
-import json
 import os
-import os.path
-from jsondiff import diff
-from include_tgram import *
+from core.version_check import fetch_json, run_check
 
-def sourceJson(path):
-    if (not os.environ.get('PYTHONHTTPSVERIFY', '') and getattr(ssl, '_create_unverified_context', None)): # Credits: https://moreless.medium.com/how-to-fix-python-ssl-certificate-verify-failed-97772d9dd14c
-        ssl._create_default_https_context = ssl._create_unverified_context
-    response = json.loads(requests.get(path).text)
-    return response
+URL = "https://api.github.com/repos/microsoft/XmlNotepad/releases/latest"
 
-def checkrepo(updates_file):
-    with open(updates_file, "r") as f:
-        content = f.read()
-        first_line = content.split('\n', 1)[0]
-    return first_line
 
-def checkversion(xmlnpversion):
-    if (xmlnpversion != checkrepo(os.path.join("updates","LATEST_XMLNP"))):
-        print("New version of XmlNotepad is available: %s, i'm updating version file." % xmlnpversion)
-        writenewversion(os.path.join("updates","LATEST_XMLNP"),xmlnpversion)
-        sendtotelegram("📝 XmlNotepad: new version available! %s \nDownload from %s" % (xmlnpversion,xmlnpJson["html_url"]))
-    else:
-        print("Latest XmlNotepad is the same of the repository, skip.")
+def fetch_xmlnp():
+    data = fetch_json(URL)
+    return {"version": data["tag_name"], "url": data["html_url"]}
 
-def writenewversion(updates_file,newversion):
-    with open(updates_file, "w") as readversion:
-        readversion.write(newversion)
-    return
 
-xmlnpJson = sourceJson("https://api.github.com/repos/microsoft/XmlNotepad/releases/latest") # Credits: https://stackoverflow.com/a/60716112/2220346
-checkversion(xmlnpJson["tag_name"])
+if __name__ == "__main__":
+    run_check(
+        "XmlNotepad",
+        fetch_xmlnp,
+        os.path.join("updates", "LATEST_XMLNP"),
+        "\U0001F4DD XmlNotepad: new version available! {version} \nDownload from {url}",
+    )


### PR DESCRIPTION
## Summary
- centralize version-check helper functions under `core/version_check`
- simplify each `sw_*.py` script to only fetch product versions and call the helpers

## Testing
- `python -m py_compile core/version_check.py sw_*.py`

------
https://chatgpt.com/codex/tasks/task_b_6846e2443c60832782ec099438f4ed29