### PR TITLE
Remove jsondiff dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 feedparser
 requests
-jsondiff


### PR DESCRIPTION
## Summary
- remove unused `jsondiff` from requirements

## Testing
- `python sw_firefox.py` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_6846ee8f0e4c832797792da3d96c8557