### PR TITLE
Unify SSL handling for downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ https://t.me/SWUpdate
 
 **Vuoi saperne di più sul progetto?** Leggi l'articolo dedicato su Gioxx's Wall:
 https://gioxx.org/2022/09/19/swupdates-alert-rimani-aggiornato-sul-rilascio-delle-applicazioni/
+
+Alcune fonti di aggiornamento utilizzano certificati HTTPS obsoleti. In questi
+casi gli script disabilitano temporaneamente il controllo dei certificati per
+consentire il download dei dati.

--- a/core/version_check.py
+++ b/core/version_check.py
@@ -4,12 +4,25 @@ import requests
 from include_tgram import sendtotelegram
 
 
-def fetch_json(url, verify_ssl=True):
-    """Retrieve JSON data from URL with optional SSL verification."""
-    if not verify_ssl and not os.environ.get('PYTHONHTTPSVERIFY', '') and getattr(ssl, '_create_unverified_context', None):
+def fetch_url(url, verify_ssl=True):
+    """Return a requests.Response object with optional SSL verification."""
+    if (
+        not verify_ssl
+        and not os.environ.get("PYTHONHTTPSVERIFY", "")
+        and getattr(ssl, "_create_unverified_context", None)
+    ):
         ssl._create_default_https_context = ssl._create_unverified_context
+        requests.packages.urllib3.disable_warnings(
+            requests.packages.urllib3.exceptions.InsecureRequestWarning
+        )
     response = requests.get(url, verify=verify_ssl)
     response.raise_for_status()
+    return response
+
+
+def fetch_json(url, verify_ssl=True):
+    """Retrieve JSON data from URL with optional SSL verification."""
+    response = fetch_url(url, verify_ssl=verify_ssl)
     return response.json()
 
 

--- a/sw_firma4ng.py
+++ b/sw_firma4ng.py
@@ -1,16 +1,12 @@
 import hashlib
 import os
-import ssl
-import urllib.request
-from core.version_check import run_check
+from core.version_check import run_check, fetch_url
 
 URL = "https://card.infocamere.it/infocard/FileDocManager/download?file=/firma4ng/Firma4ng_win.zip"
 
 
 def fetch_firma4ng():
-    if not os.environ.get('PYTHONHTTPSVERIFY', '') and getattr(ssl, '_create_unverified_context', None):
-        ssl._create_default_https_context = ssl._create_unverified_context
-    data = urllib.request.urlopen(URL).read()
+    data = fetch_url(URL, verify_ssl=False).content
     md5 = hashlib.md5()
     md5.update(data)
     return {"version": md5.hexdigest()}

--- a/sw_putty.py
+++ b/sw_putty.py
@@ -1,17 +1,13 @@
 import os
 import re
-import ssl
-import urllib.request
-from core.version_check import run_check
+from core.version_check import run_check, fetch_url
 
 URL = "https://www.chiark.greenend.org.uk/~sgtatham/putty/changes.html"
 DOWNLOAD_URL = "https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html"
 
 
 def fetch_putty():
-    if not os.environ.get('PYTHONHTTPSVERIFY', '') and getattr(ssl, '_create_unverified_context', None):
-        ssl._create_default_https_context = ssl._create_unverified_context
-    data = urllib.request.urlopen(URL).read().decode('utf-8')
+    data = fetch_url(URL, verify_ssl=False).text
     excluded_versions = ['0.45', '0.46', '0.47', '0.48', '0.49', '0.50', '0.51']
     matches = re.findall(r'>([0-9.]+)<\/a>\n\(released (....-..-..)', data)
     releases = [m for m in matches if m[0] not in excluded_versions]


### PR DESCRIPTION
## Summary
- centralize SSL verification logic in `core/version_check.fetch_url`
- use `fetch_url` in `fetch_json`
- simplify SSL handling in `sw_putty.py` and `sw_firma4ng.py`
- document optional certificate checks in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6846ef98c2548327aec10a95b9ed752a