### PR TITLE
Handle missing version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ https://gioxx.org/2022/09/19/swupdates-alert-rimani-aggiornato-sul-rilascio-dell
 Alcune fonti di aggiornamento utilizzano certificati HTTPS obsoleti. In questi
 casi gli script disabilitano temporaneamente il controllo dei certificati per
 consentire il download dei dati.
+
+Quando non è possibile determinare la versione di un'applicazione, il controllo viene ignorato e il file di versione non viene aggiornato.

--- a/core/version_check.py
+++ b/core/version_check.py
@@ -53,6 +53,9 @@ def run_check(name, fetch_fn, version_file, message_fmt):
     else:
         version = data
         data = {'version': version}
+    if version is None:
+        print(f"Warning: {name} version could not be determined, skipping check.")
+        return
     repo_version = read_repo_version(version_file)
     if version != repo_version:
         print(f"New version of {name} is available: {version}, updating version file.")


### PR DESCRIPTION
## Summary
- handle `None` version in `run_check`
- warn and skip updating version file when no version is detected
- document skipped checks in README

## Testing
- `python -m py_compile core/version_check.py`


------
https://chatgpt.com/codex/tasks/task_b_6846f31f47688327bf00c336ba8102f0