### PR TITLE
Fix ssl context handling in fetch_url and add unit test

### DIFF
--- a/core/version_check.py
+++ b/core/version_check.py
@@ -6,18 +6,22 @@ from include_tgram import sendtotelegram
 
 def fetch_url(url, verify_ssl=True):
     """Return a requests.Response object with optional SSL verification."""
-    if (
-        not verify_ssl
-        and not os.environ.get("PYTHONHTTPSVERIFY", "")
-        and getattr(ssl, "_create_unverified_context", None)
-    ):
-        ssl._create_default_https_context = ssl._create_unverified_context
-        requests.packages.urllib3.disable_warnings(
-            requests.packages.urllib3.exceptions.InsecureRequestWarning
-        )
-    response = requests.get(url, verify=verify_ssl)
-    response.raise_for_status()
-    return response
+    original_context = ssl._create_default_https_context
+    try:
+        if (
+            not verify_ssl
+            and not os.environ.get("PYTHONHTTPSVERIFY", "")
+            and getattr(ssl, "_create_unverified_context", None)
+        ):
+            ssl._create_default_https_context = ssl._create_unverified_context
+            requests.packages.urllib3.disable_warnings(
+                requests.packages.urllib3.exceptions.InsecureRequestWarning
+            )
+        response = requests.get(url, verify=verify_ssl)
+        response.raise_for_status()
+        return response
+    finally:
+        ssl._create_default_https_context = original_context
 
 
 def fetch_json(url, verify_ssl=True):

--- a/tests/test_fetch_url.py
+++ b/tests/test_fetch_url.py
@@ -1,0 +1,51 @@
+import ssl
+import unittest
+from unittest import mock
+import sys
+import types
+
+# Provide a minimal requests stub so the module under test can be imported
+requests_stub = types.SimpleNamespace()
+requests_stub.packages = types.SimpleNamespace(
+    urllib3=types.SimpleNamespace(
+        disable_warnings=lambda *args, **kwargs: None,
+        exceptions=types.SimpleNamespace(InsecureRequestWarning=object),
+    )
+)
+requests_stub.get = lambda *args, **kwargs: None
+sys.modules.setdefault("requests", requests_stub)
+
+from core.version_check import fetch_url
+
+
+class DummyResponse:
+    def __init__(self):
+        self.status_code = 200
+        self.text = "ok"
+        self.content = b"ok"
+
+    def raise_for_status(self):
+        pass
+
+
+class FetchUrlSSLContextTest(unittest.TestCase):
+    def _make_response(self):
+        return DummyResponse()
+
+    def test_context_restored_between_calls(self):
+        original = ssl._create_default_https_context
+        response = self._make_response()
+
+        with mock.patch('requests.get', return_value=response) as mock_get:
+            fetch_url('http://example.com', verify_ssl=False)
+            mock_get.assert_called_once_with('http://example.com', verify=False)
+            self.assertIs(ssl._create_default_https_context, original)
+
+        with mock.patch('requests.get', return_value=response) as mock_get:
+            fetch_url('http://example.com', verify_ssl=True)
+            mock_get.assert_called_once_with('http://example.com', verify=True)
+            self.assertIs(ssl._create_default_https_context, original)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- restore original SSL context after fetch_url
- add regression test for SSL context restoration

## Testing
- `python -m unittest discover -v tests`

------
https://chatgpt.com/codex/tasks/task_b_6846f61c0e388327824709e40d77e6c9