### PR TITLE
Improve Telegram sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ casi gli script disabilitano temporaneamente il controllo dei certificati per
 consentire il download dei dati.
 
 Quando non è possibile determinare la versione di un'applicazione, il controllo viene ignorato e il file di versione non viene aggiornato.
+
+## Variabili d'ambiente
+
+Gli script inviano notifiche su Telegram. Prima dell'esecuzione occorre impostare le seguenti variabili d'ambiente:
+
+* `TGRAMTOKEN`: token del bot Telegram
+* `TGRAMCHATID`: ID della chat alla quale inviare i messaggi

--- a/include_tgram.py
+++ b/include_tgram.py
@@ -1,12 +1,18 @@
 #from dotenv import load_dotenv, find_dotenv
-import requests
 import os
 import os.path
+import requests
 
 def sendtotelegram(message):
     #load_dotenv(find_dotenv())
-    token = os.environ.get("TGRAMTOKEN").strip()
-    chatid = os.environ.get("TGRAMCHATID").strip()
-    url = "https://api.telegram.org/bot%s/sendMessage?chat_id=%s&text=%s" % (token, chatid, message)
-    response = requests.post(url)
+    token = os.environ.get("TGRAMTOKEN")
+    chatid = os.environ.get("TGRAMCHATID")
+
+    if not token:
+        raise EnvironmentError("TGRAMTOKEN environment variable is missing")
+    if not chatid:
+        raise EnvironmentError("TGRAMCHATID environment variable is missing")
+
+    url = f"https://api.telegram.org/bot{token.strip()}/sendMessage"
+    response = requests.post(url, data={"chat_id": chatid.strip(), "text": message})
     return response


### PR DESCRIPTION
## Summary
- handle missing Telegram environment variables
- use `requests.post` with parameters
- document `TGRAMTOKEN` and `TGRAMCHATID` in the README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6846f79d5bc88327b247f3edaf8bbf4a