### PR TITLE
Switch FileZilla to update API

### DIFF
--- a/sw_filezilla.py
+++ b/sw_filezilla.py
@@ -1,32 +1,18 @@
 import os
-import re
 import requests
-from core.version_check import run_check
+from core.version_check import fetch_json, run_check
 
 
-URL = "https://filezilla-project.org/download.php?show_all=1"
-
-
-def get_latest_version_from_html(url):
-    session = requests.Session()
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-    }
-    try:
-        response = session.get(url, headers=headers, timeout=10)
-        response.raise_for_status()
-        html_content = response.text
-        match = re.search(r'FileZilla_(\d+\.\d+\.\d+)_', html_content)
-        if match:
-            return match.group(1)
-    except requests.RequestException as e:
-        print(f"Error fetching the page: {e}")
-    return None
+URL = "https://update.filezilla-project.org/update.php?type=client&channel=release&format=1"
 
 
 def fetch_filezilla():
-    version = get_latest_version_from_html(URL)
-    return {"version": version}
+    try:
+        data = fetch_json(URL)
+        return data.get("version")
+    except requests.RequestException as e:
+        print(f"Error fetching FileZilla update information: {e}")
+        return None
 
 
 if __name__ == "__main__":

--- a/tests/test_filezilla.py
+++ b/tests/test_filezilla.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest import mock
+import sys
+import types
+
+# Ensure a requests stub exists and provide minimal attributes needed for the
+# modules under test.
+requests_stub = sys.modules.get("requests")
+if requests_stub is None:
+    requests_stub = types.SimpleNamespace()
+    sys.modules["requests"] = requests_stub
+
+requests_stub.RequestException = Exception
+requests_stub.get = getattr(requests_stub, "get", lambda *args, **kwargs: None)
+requests_stub.packages = getattr(
+    requests_stub,
+    "packages",
+    types.SimpleNamespace(
+        urllib3=types.SimpleNamespace(
+            disable_warnings=lambda *a, **k: None,
+            exceptions=types.SimpleNamespace(InsecureRequestWarning=object),
+        )
+    ),
+)
+
+requests = requests_stub
+
+from sw_filezilla import fetch_filezilla
+
+
+class FilezillaFetchTests(unittest.TestCase):
+    def test_success(self):
+        with mock.patch('sw_filezilla.fetch_json', return_value={'version': '1.2.3'}):
+            self.assertEqual(fetch_filezilla(), '1.2.3')
+
+    def test_network_error_returns_none(self):
+        with mock.patch('sw_filezilla.fetch_json', side_effect=requests.RequestException):
+            self.assertIsNone(fetch_filezilla())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- fetch FileZilla version via the update API instead of scraping HTML
- handle network errors by returning `None`
- add unit tests for the new fetch function

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6846f9a164208327aea8418b716c142b