### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/software.yml
+++ b/.github/workflows/software.yml
@@ -5,6 +5,9 @@ on:
     - cron: '30 9 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   swcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gioxx/SWUpdates-Alert/security/code-scanning/11](https://github.com/gioxx/SWUpdates-Alert/security/code-scanning/11)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's functionality:
- `contents: write` is needed for the `git-auto-commit-action` to commit changes to the repository.
- `contents: read` is sufficient for other steps like `actions/checkout`.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job (`swcheck`) in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
