### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/IssueAssignment.yml
+++ b/.github/workflows/IssueAssignment.yml
@@ -1,5 +1,8 @@
 name: Issue assignment
 
+permissions:
+    issues: write
+
 on:
     issues:
         types: [opened]


### PR DESCRIPTION
Potential fix for [https://github.com/gioxx/SWUpdates-Alert/security/code-scanning/4](https://github.com/gioxx/SWUpdates-Alert/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Since the workflow interacts with issues, we will grant `issues: write` permission while setting all other permissions to `read` or omitting them entirely. This ensures the workflow has only the permissions it needs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
