### PR TITLE
Update FileZilla check to skip SSL validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ https://gioxx.org/2022/09/19/swupdates-alert-rimani-aggiornato-sul-rilascio-dell
 
 Alcune fonti di aggiornamento utilizzano certificati HTTPS obsoleti. In questi
 casi gli script disabilitano temporaneamente il controllo dei certificati per
-consentire il download dei dati.
+consentire il download dei dati. Il controllo per FileZilla, ad esempio,
+disattiva la verifica perché il server utilizza un certificato autofirmato.
 
 Quando non è possibile determinare la versione di un'applicazione, il controllo viene ignorato e il file di versione non viene aggiornato.
 

--- a/sw_filezilla.py
+++ b/sw_filezilla.py
@@ -8,7 +8,7 @@ URL = "https://update.filezilla-project.org/update.php?type=client&channel=relea
 
 def fetch_filezilla():
     try:
-        data = fetch_json(URL)
+        data = fetch_json(URL, verify_ssl=False)
         return data.get("version")
     except requests.RequestException as e:
         print(f"Error fetching FileZilla update information: {e}")


### PR DESCRIPTION
## Summary
- skip SSL verification when fetching FileZilla release info
- document the SSL exception for FileZilla in the README

## Testing
- `PYTHONPATH=. pytest tests/test_fetch_url.py tests/test_filezilla.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68493b66ecb88327bc8fe6151e3c704a