### PR TITLE
Update version_check.py

### DIFF
--- a/core/version_check.py
+++ b/core/version_check.py
@@ -11,7 +11,8 @@ def fetch_url(url, verify_ssl=True):
 
     headers = {}
     github_token = os.environ.get("GITHUB_TOKEN")
-    if github_token and "api.github.com" in url:
+    from urllib.parse import urlparse
+    if github_token and urlparse(url).hostname == "api.github.com":
         headers["Authorization"] = f"token {github_token}"
 
     original_context = ssl._create_default_https_context

--- a/core/version_check.py
+++ b/core/version_check.py
@@ -5,7 +5,15 @@ from include_tgram import sendtotelegram
 
 
 def fetch_url(url, verify_ssl=True):
-    """Return a requests.Response object with optional SSL verification."""
+    """Return a requests.Response object with optional SSL verification and GitHub Actions token support."""
+    import requests
+    import ssl
+
+    headers = {}
+    github_token = os.environ.get("GITHUB_TOKEN")
+    if github_token and "api.github.com" in url:
+        headers["Authorization"] = f"token {github_token}"
+
     original_context = ssl._create_default_https_context
     try:
         if (
@@ -17,15 +25,14 @@ def fetch_url(url, verify_ssl=True):
             requests.packages.urllib3.disable_warnings(
                 requests.packages.urllib3.exceptions.InsecureRequestWarning
             )
-        response = requests.get(url, verify=verify_ssl)
+        response = requests.get(url, headers=headers, verify=verify_ssl)
         response.raise_for_status()
         return response
     finally:
         ssl._create_default_https_context = original_context
 
-
 def fetch_json(url, verify_ssl=True):
-    """Retrieve JSON data from URL with optional SSL verification."""
+    """Retrieve JSON data from URL with optional SSL verification and GitHub Actions token support."""
     response = fetch_url(url, verify_ssl=verify_ssl)
     return response.json()
 


### PR DESCRIPTION
### Aumenta il rate limit GitHub API nelle Actions usando GITHUB_TOKEN

Aggiornamento della funzione `fetch_url` (e di conseguenza `fetch_json`) in `core/version_check.py` per aggiungere automaticamente l’header `Authorization` con il token `GITHUB_TOKEN` fornito da GitHub Actions quando si fanno richieste verso le API di GitHub.

- Il supporto è trasparente per tutti gli script che usano `fetch_json`.
- Si evitano errori 403 dovuti al superamento del rate limit GitHub durante le esecuzioni via Actions.
- Nessuna modifica necessaria agli script che utilizzano `fetch_json`.
- Se la variabile d’ambiente `GITHUB_TOKEN` è presente e l’URL richiesto è verso `api.github.com`, il token viene aggiunto nell’header `Authorization`.
- Per tutte le altre richieste il comportamento resta invariato.
